### PR TITLE
switch to json! for readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2703,6 +2703,7 @@ dependencies = [
  "rayon",
  "reedline",
  "rstest",
+ "serde_json",
  "serial_test",
  "signal-hook",
  "simplelog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ rayon = "1.7.0"
 is_executable = "1.0.1"
 simplelog = "0.12.0"
 time = "0.3.12"
+serde_json = "1.0"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Our dependencies don't use OpenSSL on Windows


### PR DESCRIPTION
# Description

This PR just changes the json parts to use serde-json's json! macro so that it's a little more readable.
  
# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
